### PR TITLE
refactor: use a queue-based approach rather than a recursive approach to searching the timeseries

### DIFF
--- a/position-share/src/lib.rs
+++ b/position-share/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(impl_trait_in_assoc_type)]
 use chrono::{DateTime, Utc};
+use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use uuid::Uuid;
 
@@ -204,8 +205,6 @@ fn distance_from_line(start: &Coordinate, end: &Coordinate, coordinate: &Coordin
     // The perpendicular distance is the magnitude of the cross product divided by the magnitude of the line vector
     cross_product_magnitude / line_magnitude
 }
-
-use std::cmp::Reverse;
 
 #[derive(Debug)]
 struct Results<'a> {

--- a/position-share/src/novelty.rs
+++ b/position-share/src/novelty.rs
@@ -1,0 +1,61 @@
+use std::cmp::Ordering;
+
+use uuid::Uuid;
+
+use crate::probability::Probability;
+
+#[derive(Debug, PartialEq)]
+pub struct Novelty {
+    pub distance: f64,
+    pub probability_already_transmitted: Probability,
+    pub id: Uuid,
+}
+
+impl Novelty {
+    pub fn score(&self) -> f64 {
+        self.distance * self.probability_already_transmitted.complement()
+    }
+}
+
+impl Ord for Novelty {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.score()
+            .partial_cmp(&other.score())
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| {
+                self.probability_already_transmitted
+                    .cmp(&other.probability_already_transmitted)
+            })
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+impl PartialOrd for Novelty {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for Novelty {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compare() {
+        let a = Novelty {
+            distance: 2.0,
+            probability_already_transmitted: Probability::ZERO,
+            id: Uuid::new_v4(),
+        };
+        let b = Novelty {
+            distance: 1.0,
+            probability_already_transmitted: Probability::ZERO,
+            id: Uuid::new_v4(),
+        };
+        dbg!(a.score());
+        dbg!(b.score());
+        assert!(a > b);
+    }
+}

--- a/position-share/src/novelty.rs
+++ b/position-share/src/novelty.rs
@@ -54,8 +54,6 @@ mod tests {
             probability_already_transmitted: Probability::ZERO,
             id: Uuid::new_v4(),
         };
-        dbg!(a.score());
-        dbg!(b.score());
         assert!(a > b);
     }
 }

--- a/position-share/src/probability.rs
+++ b/position-share/src/probability.rs
@@ -60,3 +60,23 @@ impl From<Probability> for f64 {
         Self::from(value.value) / Self::from(u32::MAX) * 100.0
     }
 }
+
+impl Ord for Probability {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl PartialOrd for Probability {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Probability {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl Eq for Probability {}


### PR DESCRIPTION
this is slightly more performant, and also allows a 'breadth-first' search which opens the door to using stop conditions to improve the performance in future PRs